### PR TITLE
If statement in makeDeposit removed

### DIFF
--- a/contracts/GoodGhosting.sol
+++ b/contracts/GoodGhosting.sol
@@ -106,14 +106,10 @@ contract GoodGhosting {
         emit SendMessage(msg.sender, "game joined");
     }
 
-    // only for use in test env to check internal function
-    // function testMakePayout() public returns (uint) {
-    //     require(msg.sender == admin, "not admin");
-    //     return _makePayout();
-    // }
-
-
-    function _makePayout() internal {
+    function makePayout() public {
+        require(players[msg.sender].addr == msg.sender, "only registered players can call this method");
+        uint currentSegment = getCurrentSegment();
+        require(currentSegment > lastSegment, "too early to payout");
         emit SendMessage(msg.sender, "payout process starting");
     }
 
@@ -125,11 +121,6 @@ contract GoodGhosting {
         uint currentSegment = getCurrentSegment();
         // should not be stagging segment
         require(currentSegment > 0, "too early to pay");
-
-        if(currentSegment > lastSegment){
-            _makePayout();
-            return;
-        }
 
         //check if current segment is currently unpaid
         require(players[msg.sender].mostRecentSegmentPaid != currentSegment, "current segment already paid");


### PR DESCRIPTION
This lead to an out of gas error once I had deployed to Kovan.

I have removed the logic (if statement) which checks that the game has been completed from the `makeDeposit` function. This function was handling to much.

I have created a `makePayout` function which will be used to handle the payout. I updated the tests, and wrote a couple more to ensure:
- make payout can only be called at the end of the game
- only registered players can call make payout

I also made `getCurrentSegement` public, as it is useful for the frontend currently, and there is no reason I can see for it to be internal only.