### PR TITLE
tests have segmentLength parity with contract + fixed 1 week bug

### DIFF
--- a/contracts/GoodGhosting.sol
+++ b/contracts/GoodGhosting.sol
@@ -96,7 +96,7 @@ contract GoodGhosting {
 
 
     function joinGame() public {
-        require(now <= firstSegmentStart + 1 weeks, "game has already started");
+        require(now <= firstSegmentStart + segmentLength, "game has already started");
         Player memory newPlayer = Player({
             addr : msg.sender,
             mostRecentSegmentPaid : 0,

--- a/test/GoodGhosting.test.js
+++ b/test/GoodGhosting.test.js
@@ -17,8 +17,8 @@ contract("GoodGhosting", (accounts) => {
     let pap;
     let player1 = accounts[1];
     let player2 = accounts[2];
-    const weekInSecs = 604800;
-    const numberOfSegments = 16;
+    const weekInSecs = 180;
+    const numberOfSegments = 6;
     const daiDecimals = web3.utils.toBN(1000000000000000000);
     const segmentPayment = daiDecimals.mul(new BN(10)); //equivalent to 10 DAI
 


### PR DESCRIPTION
- segmentLength same in tests as contract
- removed the 1 week timeframe and replaced with secs (this would have caused a bug if segment time was not a week).