### PR TITLE
Pull aToken address from Aave contracts in constructor

### DIFF
--- a/contracts/test/LendingPoolAddressesProviderMock.sol
+++ b/contracts/test/LendingPoolAddressesProviderMock.sol
@@ -24,7 +24,11 @@ contract LendingPoolAddressesProviderMock
     }
 
     function getLendingPoolCore() public override view returns (address payable) {
-        return address(uint160(address(this))); // cast to make it payalbe
+        return address(uint160(address(this))); // cast to make it payable
+    }
+
+    function getReserveATokenAddress(address _reserve) public view returns (address) {
+        return address(this);
     }
 
     function setLendingPoolCoreImpl(address _lendingPoolCore) public override {

--- a/test/GoodGhosting.test.js
+++ b/test/GoodGhosting.test.js
@@ -34,7 +34,6 @@ contract("GoodGhosting", (accounts) => {
         await pap.setUnderlyingAssetAddress(token.address);
         goodGhosting = await web3tx(GoodGhosting.new, "GoodGhosting.new")(
             token.address,
-            aToken.address,
             pap.address,
             segmentCount,
             segmentLength,


### PR DESCRIPTION
Currently if there's a mistake in the constructor arguments the user funds could be irretrievably lost (and people are likely to only notice once all deposits have been made). I've updated the constructor to pull the correct aToken address from Aave and to revert if it can't find a matching aToken.