### PR TITLE
Fix duplicate calls to Aave contracts and reading immutable var in constructor.

### DIFF
--- a/contracts/GoodGhosting.sol
+++ b/contracts/GoodGhosting.sol
@@ -97,8 +97,9 @@ contract GoodGhosting is Ownable, Pausable {
         lendingPoolAddressProvider = _lendingPoolAddressProvider;
 
         ILendingPoolCore lendingPoolCore = ILendingPoolCore(_lendingPoolAddressProvider.getLendingPoolCore());
-        adaiToken = AToken(lendingPoolCore.getReserveATokenAddress(address(_inboundCurrency)));
-        require(address(adaiToken) != address(0), "Aave doesn't support _inboundCurrency");
+        address adaiTokenAddress = lendingPoolCore.getReserveATokenAddress(address(_inboundCurrency));
+        require(adaiTokenAddress != address(0), "Aave doesn't support _inboundCurrency");
+        adaiToken = AToken(adaiTokenAddress);
 
         // Allows the lending pool to convert DAI deposited on this contract to aDAI on lending pool
         uint MAX_ALLOWANCE = 2**256 - 1;

--- a/contracts/GoodGhosting.sol
+++ b/contracts/GoodGhosting.sol
@@ -96,14 +96,13 @@ contract GoodGhosting is Ownable, Pausable {
         daiToken = _inboundCurrency;
         lendingPoolAddressProvider = _lendingPoolAddressProvider;
 
-        ILendingPoolCore lendingPoolCore = ILendingPoolCore(lendingPoolAddressProvider.getLendingPoolCore());
+        ILendingPoolCore lendingPoolCore = ILendingPoolCore(_lendingPoolAddressProvider.getLendingPoolCore());
         adaiToken = AToken(lendingPoolCore.getReserveATokenAddress(address(_inboundCurrency)));
         require(address(adaiToken) != address(0), "Aave doesn't support _inboundCurrency");
 
         // Allows the lending pool to convert DAI deposited on this contract to aDAI on lending pool
         uint MAX_ALLOWANCE = 2**256 - 1;
-        address core = _lendingPoolAddressProvider.getLendingPoolCore();
-        _inboundCurrency.approve(core, MAX_ALLOWANCE);
+        _inboundCurrency.approve(address(lendingPoolCore), MAX_ALLOWANCE);
     }
 
     function pause() public onlyOwner whenNotPaused {


### PR DESCRIPTION
Just noticed that you already had a `getLendingPoolCore` call in the constructor which I duplicated, wasting gas. I've removed this extra call.

I also noticed that #47 and #49 have combined in a bit of an awkward way so that the contract doesn't compile anymore because it was trying to read an immutable variable in the constructor. I've modified it so that it no longer reads this variable.