### PR TITLE
Remove redundant check on length of winners

### DIFF
--- a/contracts/GoodGhosting.sol
+++ b/contracts/GoodGhosting.sol
@@ -371,10 +371,7 @@ contract GoodGhosting is Ownable, Pausable, GoodGhostingWhitelisted {
             // Player is a winner and gets a bonus!
             // No need to worry about if winners.length = 0
             // If we're in this block then the user is a winner
-            // only add interest if there are winners
-            if (winners.length > 0) {
-                payout = payout.add(totalGameInterest.div(winners.length));
-            }
+            payout = payout.add(totalGameInterest.div(winners.length));
         }
         emit Withdrawal(msg.sender, payout);
 

--- a/contracts/GoodGhosting_Matic.sol
+++ b/contracts/GoodGhosting_Matic.sol
@@ -516,10 +516,7 @@ contract GoodGhostingMatic is Ownable, Pausable {
             // Player is a winner and gets a bonus!
             // No need to worry about if winners.length = 0
             // If we're in this block then the user is a winner
-            // only add interest if there are winners
-            if (winners.length > 0) {
-                payout = payout.add(totalGameInterest / winners.length);
-            }
+            payout = payout.add(totalGameInterest / winners.length);
         }
         emit Withdrawal(msg.sender, payout);
 


### PR DESCRIPTION
This condition is redundant as it's weaker than the outer condition that the user is a winner.