### PR TITLE
Remove Quickswap from polygon contract

### DIFF
--- a/contracts/GoodGhosting.sol
+++ b/contracts/GoodGhosting.sol
@@ -160,7 +160,7 @@ contract GoodGhosting is Ownable, Pausable, GoodGhostingWhitelisted {
     /**
        Allowing the admin to withdraw the pool fees
     */
-    function adminFeeWithdraw() external onlyOwner whenGameIsCompleted {
+    function adminFeeWithdraw() external virtual  onlyOwner whenGameIsCompleted {
         require(!adminWithdraw, "Admin has already withdrawn");
         require(adminFeeAmount > 0, "No Fees Earned");
         adminWithdraw = true;
@@ -379,7 +379,7 @@ contract GoodGhosting is Ownable, Pausable, GoodGhostingWhitelisted {
     }
 
     // to be called by individual players to get the amount back once it is redeemed following the solidity withdraw pattern
-    function withdraw() external {
+    function withdraw() external virtual {
         Player storage player = players[msg.sender];
         require(!player.withdrawn, "Player has already withdrawn");
         player.withdrawn = true;

--- a/contracts/GoodGhosting_Polygon.sol
+++ b/contracts/GoodGhosting_Polygon.sol
@@ -8,7 +8,6 @@ import "./aave/ILendingPoolAddressesProvider.sol";
 import "./aave/ILendingPool.sol";
 import "./aave/AToken.sol";
 import "./aave/IncentiveController.sol";
-import "./quickswap/IRouter.sol";
 import "./GoodGhostingWhitelisted.sol";
 import "./GoodGhosting.sol";
 
@@ -19,10 +18,8 @@ import "./GoodGhosting.sol";
 
 contract GoodGhostingPolygon is GoodGhosting {
     IncentiveController public incentiveController;
-    IRouter public router;
     IERC20 public immutable matic;
-    // as discussed the dai apy on polygon is prettu high so the deposit asset will be dai only hence there is a change in route: wmatic -> usdc -> dai
-    IERC20 public immutable usdc;
+    uint public rewardsPerPlayer;
 
     /**
         Creates a new instance of GoodGhosting game
@@ -36,9 +33,7 @@ contract GoodGhostingPolygon is GoodGhosting {
         @param _dataProvider id for getting the data provider contract address 0x1 to be passed.
         @param merkleRoot_ merkel root to verify players on chain to allow only whitelisted users join.
         @param _incentiveController $matic reward claim contract.
-        @param _router quickswap router address.
         @param _matic matic token address.
-        @param _usdc usdc token address.
      */
     constructor(
         IERC20 _inboundCurrency,
@@ -51,9 +46,7 @@ contract GoodGhostingPolygon is GoodGhosting {
         address _dataProvider,
         bytes32 merkleRoot_,
         address _incentiveController,
-        IRouter _router,
-        IERC20 _matic,
-        IERC20 _usdc
+        IERC20 _matic
     )
         public
         GoodGhosting(
@@ -71,14 +64,62 @@ contract GoodGhostingPolygon is GoodGhosting {
         // initializing incentiveController contract
         incentiveController = IncentiveController(_incentiveController);
         matic = _matic;
-        usdc = _usdc;
-        router = _router;
-        uint256 MAX_ALLOWANCE = 2**256 - 1;
-        // for the swap
-         require(
-            _matic.approve(address(_router), MAX_ALLOWANCE),
-            "Fail to approve allowance to router"
+    }
+
+    /**
+       Allowing the admin to withdraw the pool fees
+    */
+    function adminFeeWithdraw() external override  onlyOwner whenGameIsCompleted {
+        require(!adminWithdraw, "Admin has already withdrawn");
+        require(adminFeeAmount > 0, "No Fees Earned");
+        adminWithdraw = true;
+        emit AdminWithdrawal(owner(), totalGameInterest, adminFeeAmount);
+        require(
+            IERC20(daiToken).transfer(owner(), adminFeeAmount),
+            "Fail to transfer ER20 tokens to admin"
         );
+        if (rewardsPerPlayer == 0) {
+        uint balance = IERC20(matic).balanceOf(address(this));
+        require(
+            IERC20(matic).transfer(msg.sender, balance),
+            "Fail to transfer ERC20 tokens on withdraw"
+        );
+        }
+    }
+
+    // to be called by individual players to get the amount back once it is redeemed following the solidity withdraw pattern
+    function withdraw() public override {
+        Player storage player = players[msg.sender];
+        require(!player.withdrawn, "Player has already withdrawn");
+        player.withdrawn = true;
+
+        uint256 payout = player.amountPaid;
+        if (player.mostRecentSegmentPaid == lastSegment.sub(1)) {
+            // Player is a winner and gets a bonus!
+            // No need to worry about if winners.length = 0
+            // If we're in this block then the user is a winner
+            payout = payout.add(totalGameInterest.div(winners.length));
+        }
+        emit Withdrawal(msg.sender, payout);
+
+        // First player to withdraw redeems everyone's funds
+        if (!redeemed) {
+            redeemFromExternalPool();
+        }
+
+        require(
+            IERC20(daiToken).transfer(msg.sender, payout),
+            "Fail to transfer ERC20 tokens on withdraw"
+        );
+        // doing the transfer in the end as per the checks and effects pattern
+        if (player.mostRecentSegmentPaid == lastSegment.sub(1)) {
+        if (rewardsPerPlayer > 0) {
+        require(
+            IERC20(matic).transfer(msg.sender, rewardsPerPlayer),
+            "Fail to transfer ERC20 tokens on withdraw"
+        );
+        }
+        }
     }
 
     /**
@@ -92,6 +133,7 @@ contract GoodGhostingPolygon is GoodGhosting {
         // aave has 1:1 peg for tokens and atokens
         // there is no redeem function in v2 it is replaced by withdraw in v2
         // Aave docs recommends using uint(-1) to withdraw the full balance. This is actually an overflow that results in the max uint256 value.
+        uint256 amount;
         if (adaiToken.balanceOf(address(this)) > 0) {
             lendingPool.withdraw(
                 address(daiToken),
@@ -100,7 +142,7 @@ contract GoodGhostingPolygon is GoodGhosting {
             );
             address[] memory assets = new address[](1);
             assets[0] = address(adaiToken);
-            uint256 amount = incentiveController.getRewardsBalance(
+            amount = incentiveController.getRewardsBalance(
                 assets,
                 address(this)
             );
@@ -110,19 +152,6 @@ contract GoodGhostingPolygon is GoodGhosting {
                     amount,
                     address(this)
                 );
-                address[] memory pairTokens = new address[](3);
-                // route considering dai only as the game asset
-                pairTokens[0] = address(matic);
-                pairTokens[1] = address(usdc);
-                pairTokens[2] = address(daiToken);
-                uint[] memory swapAmounts = router.swapExactTokensForTokens(
-                    amount,
-                    0,
-                    pairTokens,
-                    address(this),
-                    now.add(1200)
-                );
-                require(swapAmounts.length > 1, "Router.swapExactTokensForTokens: no output token amount returned");
             }
         }
 
@@ -140,8 +169,10 @@ contract GoodGhostingPolygon is GoodGhosting {
         }
 
         if (winners.length == 0) {
+            rewardsPerPlayer = 0;
             adminFeeAmount = grossInterest;
         } else {
+            rewardsPerPlayer = amount.div(winners.length);
             adminFeeAmount = _adminFeeAmount;
         }
 

--- a/contracts/GoodGhosting_Polygon.sol
+++ b/contracts/GoodGhosting_Polygon.sol
@@ -79,11 +79,11 @@ contract GoodGhostingPolygon is GoodGhosting {
             "Fail to transfer ER20 tokens to admin"
         );
         if (rewardsPerPlayer == 0) {
-        uint balance = IERC20(matic).balanceOf(address(this));
-        require(
-            IERC20(matic).transfer(msg.sender, balance),
-            "Fail to transfer ERC20 tokens on withdraw"
-        );
+            uint balance = IERC20(matic).balanceOf(address(this));
+            require(
+                IERC20(matic).transfer(msg.sender, balance),
+                "Fail to transfer ERC20 tokens on withdraw"
+            );
         }
     }
 
@@ -94,11 +94,13 @@ contract GoodGhostingPolygon is GoodGhosting {
         player.withdrawn = true;
 
         uint256 payout = player.amountPaid;
+        uint256 playerReward = 0;
         if (player.mostRecentSegmentPaid == lastSegment.sub(1)) {
             // Player is a winner and gets a bonus!
             // No need to worry about if winners.length = 0
             // If we're in this block then the user is a winner
             payout = payout.add(totalGameInterest.div(winners.length));
+            playerReward = rewardsPerPlayer;
         }
         emit Withdrawal(msg.sender, payout);
 
@@ -111,14 +113,12 @@ contract GoodGhostingPolygon is GoodGhosting {
             IERC20(daiToken).transfer(msg.sender, payout),
             "Fail to transfer ERC20 tokens on withdraw"
         );
-        // doing the transfer in the end as per the checks and effects pattern
-        if (player.mostRecentSegmentPaid == lastSegment.sub(1)) {
-        if (rewardsPerPlayer > 0) {
-        require(
-            IERC20(matic).transfer(msg.sender, rewardsPerPlayer),
-            "Fail to transfer ERC20 tokens on withdraw"
-        );
-        }
+
+        if (playerReward > 0) {
+            require(
+                IERC20(matic).transfer(msg.sender, playerReward),
+                "Fail to transfer ERC20 rewards on withdraw"
+            );
         }
     }
 

--- a/deploy.config.js
+++ b/deploy.config.js
@@ -20,8 +20,6 @@ exports.providers = {
             lendingPoolAddressProvider: "0xd05e3E715d945B59290df0ae8eF85c1BdB684744",
             dataProvider: "0x7551b5D2763519d4e37e8B81929D336De671d46d",
             incentiveController: '0x357D51124f59836DeD84c8a1730D72B749d8BC23',
-            router: '0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff',
-            usdc: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
             wmatic: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
             dai: {
                 address: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -40,9 +40,7 @@ function printSummary(
         aaveContractAddress,
         merkleRoot,
         incentiveController,
-        router,
-        wmatic,
-        usdc
+        wmatic
     },
     // additional logging info
     {
@@ -81,15 +79,11 @@ function printSummary(
     if (isPolygon) {
         parameterTypes.push(
             "address", // IncentiveController
-            "address", // QuickSwap router
-            "address", // wmatic token
-            "address" // usdc token
+            "address" // wmatic token
         );
         parameterValues.push(
             incentiveController,
-            router,
-            wmatic,
-            usdc
+            wmatic
         );
     }
 
@@ -111,9 +105,7 @@ function printSummary(
     console.log(`Merkle Root: ${merkleRoot}`);
     if (isPolygon) {
         console.log(`Incentive Controller: ${incentiveController}`);
-        console.log(`QuickSwap Router: ${router}`);
         console.log(`Matic Token: ${wmatic}`);
-        console.log(`USDC Token: ${usdc}`);
     }
     console.log("\n\nConstructor Arguments ABI-Encoded:");
     console.log(encodedParameters.toString("hex"));
@@ -137,8 +129,6 @@ module.exports = function (deployer, network, accounts) {
         const inboundCurrencyDecimals = poolConfigs[deployConfigs.inboundCurrencySymbol.toLowerCase()].decimals;
         const segmentPaymentWei = new BN(deployConfigs.segmentPayment).mul(new BN(10).pow(new BN(inboundCurrencyDecimals)));
         const incentiveController = poolConfigs.incentiveController;
-        const router = poolConfigs.router;
-        const usdc = poolConfigs.usdc;
         const wmatic = poolConfigs.wmatic;
 
         let aaveContractAddress = poolConfigs.dataProvider;
@@ -167,9 +157,7 @@ module.exports = function (deployer, network, accounts) {
         if (networkName === "polygon") {
             deploymentArgs.push(
                 incentiveController,
-                router,
-                wmatic,
-                usdc
+                wmatic
             );
         }
 
@@ -191,9 +179,7 @@ module.exports = function (deployer, network, accounts) {
                 aaveContractAddress,
                 merkleRoot: deployConfigs.merkleroot,
                 incentiveController,
-                router,
-                wmatic,
-                usdc
+                wmatic
             },
             {
                 networkName,

--- a/test/GoodGhostingGasEstimate.test.js
+++ b/test/GoodGhostingGasEstimate.test.js
@@ -188,12 +188,16 @@ contract("GoodGhostingGasEstimate", (accounts) => {
             // starts from 1, since player1 (loser), requested an early withdraw
             for (let i = 1; i < players.length - 1; i++) {
                 const player = players[i];
+                let playerMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    playerMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                }
                 const result = await goodGhosting.withdraw({ from: player });
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
-                        return ev.player === player && playersMaticBalance.gt(new BN(0));
+                        return ev.player === player && playersMaticBalance.gt(playerMaticBalanceBeforeWithdraw);
                     } else {
                         return ev.player === player;
                     }

--- a/test/GoodGhostingGasEstimate.test.js
+++ b/test/GoodGhostingGasEstimate.test.js
@@ -206,6 +206,10 @@ contract("GoodGhostingGasEstimate", (accounts) => {
                 await truffleAssert.reverts(goodGhosting.adminFeeWithdraw({ from: admin }), "No Fees Earned");
             } else {
                 const expectedAmount = new BN(await goodGhosting.adminFeeAmount.call({from: admin}));
+                let adminMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    adminMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
+                }
                 const result = await goodGhosting.adminFeeWithdraw({ from: admin });
                 if (GoodGhostingArtifact === GoodGhostingPolygon) {
                     const adminMaticBalance = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
@@ -214,7 +218,7 @@ contract("GoodGhostingGasEstimate", (accounts) => {
                         result,
                         "AdminWithdrawal",
                         (ev) => {
-                            return expectedAmount.eq(ev.adminFeeAmount) && adminMaticBalance.eq(new BN(0));
+                            return expectedAmount.eq(ev.adminFeeAmount) && adminMaticBalance.eq(adminMaticBalanceBeforeWithdraw);
                         });
                 } else {
                     truffleAssert.eventEmitted(

--- a/test/GoodGhostingGasEstimate.test.js
+++ b/test/GoodGhostingGasEstimate.test.js
@@ -44,6 +44,7 @@ contract("GoodGhostingGasEstimate", (accounts) => {
     describe("simulates a full game with 5 players and 4 of them winning the game and with admin fee % as 0", async () => {
         it("initializes contract instances and transfers DAI to players", async () => {
             token = new web3.eth.Contract(daiABI, providersConfigs.dai.address);
+            rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
             goodGhosting = await GoodGhostingArtifact.deployed();
             // Send 1 eth to token address to have gas to transfer DAI.
             // Uses ForceSend contract, otherwise just sending a normal tx will revert.
@@ -191,7 +192,6 @@ contract("GoodGhostingGasEstimate", (accounts) => {
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
-                        rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
                         return ev.player === player && playersMaticBalance.gt(new BN(0));
                     } else {
@@ -208,7 +208,6 @@ contract("GoodGhostingGasEstimate", (accounts) => {
                 const expectedAmount = new BN(await goodGhosting.adminFeeAmount.call({from: admin}));
                 const result = await goodGhosting.adminFeeWithdraw({ from: admin });
                 if (GoodGhostingArtifact === GoodGhostingPolygon) {
-                    rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
                     const adminMaticBalance = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
 
                     truffleAssert.eventEmitted(
@@ -216,14 +215,14 @@ contract("GoodGhostingGasEstimate", (accounts) => {
                         "AdminWithdrawal",
                         (ev) => {
                             return expectedAmount.eq(ev.adminFeeAmount) && adminMaticBalance.eq(new BN(0));
-                        })
+                        });
                 } else {
                     truffleAssert.eventEmitted(
                         result,
                         "AdminWithdrawal",
                         (ev) => {
                             return expectedAmount.eq(ev.adminFeeAmount);
-                        })
+                        });
                 }
 
             }

--- a/test/GoodGhosting_Attacker_Sends_DAI_Externally.test.js
+++ b/test/GoodGhosting_Attacker_Sends_DAI_Externally.test.js
@@ -202,6 +202,10 @@ contract("GoodGhosting_Attacker_Sends_DAI_Externally", (accounts) => {
             if (!customFee) {
                 await truffleAssert.reverts(goodGhosting.adminFeeWithdraw({ from: admin }), "No Fees Earned");
             } else {
+                let adminMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    adminMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
+                }
                 const result = await goodGhosting.adminFeeWithdraw({ from: admin });
                 if (GoodGhostingArtifact === GoodGhostingPolygon) {
                     const adminMaticBalance = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
@@ -210,7 +214,7 @@ contract("GoodGhosting_Attacker_Sends_DAI_Externally", (accounts) => {
                         "AdminWithdrawal",
                         (ev) => {
                             const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
-                            return adminFee.lte(ev.adminFeeAmount) && adminMaticBalance.eq(new BN(0));
+                            return adminFee.lte(ev.adminFeeAmount) && adminMaticBalance.eq(adminMaticBalanceBeforeWithdraw);
                         });
                 } else {
                     truffleAssert.eventEmitted(

--- a/test/GoodGhosting_Attacker_Sends_DAI_Externally.test.js
+++ b/test/GoodGhosting_Attacker_Sends_DAI_Externally.test.js
@@ -183,14 +183,17 @@ contract("GoodGhosting_Attacker_Sends_DAI_Externally", (accounts) => {
             for (let i = 1; i < players.length - 1; i++) {
                 const player = players[i];
                 const playerInfo = await goodGhosting.players(player, { from: player });
-
+                let playerMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    playerMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                }
                 const result = await goodGhosting.withdraw({ from: player });
 
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
-                        return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid) && playersMaticBalance.gt(new BN(0));
+                        return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid) && playersMaticBalance.gt(playerMaticBalanceBeforeWithdraw);
                     } else {
                         return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid);
                     }

--- a/test/GoodGhosting_Funds_Redeemed_From_Contract_On_EarlyWithdraw.test.js
+++ b/test/GoodGhosting_Funds_Redeemed_From_Contract_On_EarlyWithdraw.test.js
@@ -33,6 +33,7 @@ contract("GoodGhosting_Funds_Redeemed_On_Early_Withdraw", (accounts) => {
     const { segmentCount, segmentLength, segmentPayment: segmentPaymentInt, customFee } = configs.deployConfigs;
     const BN = web3.utils.BN; // https://web3js.readthedocs.io/en/v1.2.7/web3-utils.html#bn
     let token;
+    let rewardToken;
     let admin = accounts[0];
     const players = accounts.slice(1, 6); // 5 players
     const loser = players[0];
@@ -198,9 +199,15 @@ contract("GoodGhosting_Funds_Redeemed_On_Early_Withdraw", (accounts) => {
             for (let i = 2; i < players.length - 1; i++) {
                 const player = players[i];
                 const result = await goodGhosting.withdraw({ from: player });
-                truffleAssert.eventEmitted(result, "Withdrawal", (ev) => {
+                truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
-                    return ev.player === player;
+                    if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                        rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
+                        const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                        return ev.player === player && playersMaticBalance.gt(new BN(0));
+                    } else {
+                        return ev.player === player;
+                    }
                 }, "unable to withdraw amount");
             }
         });
@@ -210,13 +217,25 @@ contract("GoodGhosting_Funds_Redeemed_On_Early_Withdraw", (accounts) => {
                 await truffleAssert.reverts(goodGhosting.adminFeeWithdraw({ from: admin }), "No Fees Earned");
             } else {
                 const result = await goodGhosting.adminFeeWithdraw({ from: admin });
-                truffleAssert.eventEmitted(
-                    result,
-                    "AdminWithdrawal",
-                    (ev) => {
-                        const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
-                        return adminFee.lte(ev.adminFeeAmount);
-                    });
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
+                    const adminMaticBalance = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
+                    truffleAssert.eventEmitted(
+                        result,
+                        "AdminWithdrawal",
+                        (ev) => {
+                            const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
+                                return adminFee.lte(ev.adminFeeAmount) && adminMaticBalance.eq(new BN(0));
+                        });
+                } else {
+                    truffleAssert.eventEmitted(
+                        result,
+                        "AdminWithdrawal",
+                        (ev) => {
+                            const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
+                                return adminFee.lte(ev.adminFeeAmount);
+                        });
+                }
                 await truffleAssert.reverts(goodGhosting.adminFeeWithdraw({ from: admin }), "Admin has already withdrawn");
             }
         });

--- a/test/GoodGhosting_Funds_Redeemed_From_Contract_On_EarlyWithdraw.test.js
+++ b/test/GoodGhosting_Funds_Redeemed_From_Contract_On_EarlyWithdraw.test.js
@@ -199,12 +199,16 @@ contract("GoodGhosting_Funds_Redeemed_On_Early_Withdraw", (accounts) => {
             // starts from 2, since player1 (loser) and player2 (secondLoser), requested an early withdraw
             for (let i = 2; i < players.length - 1; i++) {
                 const player = players[i];
+                let playerMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    playerMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                }
                 const result = await goodGhosting.withdraw({ from: player });
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
-                        return ev.player === player && playersMaticBalance.gt(new BN(0));
+                        return ev.player === player && playersMaticBalance.gt(playerMaticBalanceBeforeWithdraw);
                     } else {
                         return ev.player === player;
                     }

--- a/test/GoodGhosting_No_External_Pool_Deposits.test.js
+++ b/test/GoodGhosting_No_External_Pool_Deposits.test.js
@@ -44,6 +44,7 @@ contract("GoodGhosting_No_External_Pool_Deposit", (accounts) => {
     describe("simulates a full game with 5 players and 4 of them winning the game with no external deposits", async () => {
         it("initializes contract instances and transfers DAI to players", async () => {
             token = new web3.eth.Contract(daiABI, providersConfigs.dai.address);
+            rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
             goodGhosting = await GoodGhostingArtifact.deployed();
             // Send 1 eth to token address to have gas to transfer DAI.
             // Uses ForceSend contract, otherwise just sending a normal tx will revert.
@@ -176,7 +177,6 @@ contract("GoodGhosting_No_External_Pool_Deposit", (accounts) => {
                     console.log(`player${i+1} withdraw amount: ${ev.amount.toString()}`);
                     const eventAmount = new BN(ev.amount.toString());
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
-                        rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
                         return ev.player === player && playerPayment.eq(eventAmount) && playersMaticBalance.eq(new BN(0));
                     } else {

--- a/test/GoodGhosting_No_External_Pool_Deposits.test.js
+++ b/test/GoodGhosting_No_External_Pool_Deposits.test.js
@@ -171,6 +171,10 @@ contract("GoodGhosting_No_External_Pool_Deposit", (accounts) => {
             // starts from 1, since player1 (loser), requested an early withdraw
             for (let i = 1; i < players.length - 1; i++) {
                 const player = players[i];
+                let playerMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    playerMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                }
                 const result = await goodGhosting.withdraw({ from: player });
 
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
@@ -178,7 +182,7 @@ contract("GoodGhosting_No_External_Pool_Deposit", (accounts) => {
                     const eventAmount = new BN(ev.amount.toString());
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
-                        return ev.player === player && playerPayment.eq(eventAmount) && playersMaticBalance.eq(new BN(0));
+                        return ev.player === player && playerPayment.eq(eventAmount) && playersMaticBalance.eq(playerMaticBalanceBeforeWithdraw);
                     } else {
                         return ev.player === player && playerPayment.eq(eventAmount);
                     }

--- a/test/GoodGhosting_No_Player_Wins.test.js
+++ b/test/GoodGhosting_No_Player_Wins.test.js
@@ -133,12 +133,16 @@ contract("GoodGhosting_No_Player_Wins", (accounts) => {
             // starts from 1, since player1 (loser), requested an early withdraw
             for (let i = 1; i < players.length - 1; i++) {
                 const player = players[i];
+                let playerMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    playerMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                }
                 const result = await goodGhosting.withdraw({ from: player });
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
-                        return ev.player === player && playersMaticBalance.eq(new BN(0));
+                        return ev.player === player && playersMaticBalance.eq(playerMaticBalanceBeforeWithdraw);
                     } else {
                         return ev.player === player;
                     }

--- a/test/GoodGhosting_Send_AToken_Externally.test.js
+++ b/test/GoodGhosting_Send_AToken_Externally.test.js
@@ -216,13 +216,16 @@ contract("GoodGhosting_Send_AToken_Externally", (accounts) => {
                 const player = players[i];
                 const playerInfo = await goodGhosting.players(player, { from: player });
 
-                // const userDaiBalance = new BN(await token.methods.balanceOf(player).call({ from: admin }));
+                let playerMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    playerMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                }
                 const result = await goodGhosting.withdraw({ from: player });
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
-                        return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid) && playersMaticBalance.gt(new BN(0));
+                        return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid) && playersMaticBalance.gt(playerMaticBalanceBeforeWithdraw);
                     } else {
                         return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid);
                     }

--- a/test/GoodGhosting_Send_AToken_Externally.test.js
+++ b/test/GoodGhosting_Send_AToken_Externally.test.js
@@ -39,6 +39,7 @@ contract("GoodGhosting_Send_AToken_Externally", (accounts) => {
     const { segmentCount, segmentLength, segmentPayment: segmentPaymentInt, customFee } = configs.deployConfigs;
     const BN = web3.utils.BN; // https://web3js.readthedocs.io/en/v1.2.7/web3-utils.html#bn
     let token;
+    let rewardToken;
     let admin = accounts[0];
     const players = accounts.slice(1, 6); // 5 players
     const loser = players[0];
@@ -216,9 +217,15 @@ contract("GoodGhosting_Send_AToken_Externally", (accounts) => {
 
                 // const userDaiBalance = new BN(await token.methods.balanceOf(player).call({ from: admin }));
                 const result = await goodGhosting.withdraw({ from: player });
-                truffleAssert.eventEmitted(result, "Withdrawal", (ev) => {
+                truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
-                    return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid);
+                    if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                        rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
+                        const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
+                        return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid) && playersMaticBalance.gt(new BN(0));
+                    } else {
+                        return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid);
+                    }
                 }, "unable to withdraw amount");
             }
         });
@@ -228,13 +235,26 @@ contract("GoodGhosting_Send_AToken_Externally", (accounts) => {
                 await truffleAssert.reverts(goodGhosting.adminFeeWithdraw({ from: admin }), "No Fees Earned");
             } else {
                 const result = await goodGhosting.adminFeeWithdraw({ from: admin });
-                truffleAssert.eventEmitted(
-                    result,
-                    "AdminWithdrawal",
-                    (ev) => {
-                        const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
-                        return adminFee.lte(ev.adminFeeAmount);
-                    });
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
+                    const adminMaticBalance = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
+                    truffleAssert.eventEmitted(
+                        result,
+                        "AdminWithdrawal",
+                        (ev) => {
+                            const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
+                                return adminFee.lte(ev.adminFeeAmount) && adminMaticBalance.eq(new BN(0));
+                        });
+                } else {
+                    truffleAssert.eventEmitted(
+                        result,
+                        "AdminWithdrawal",
+                        (ev) => {
+                            const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
+                                return adminFee.lte(ev.adminFeeAmount);
+                        });
+                }
+
                 await truffleAssert.reverts(goodGhosting.adminFeeWithdraw({ from: admin }), "Admin has already withdrawn");
             }
         });

--- a/test/GoodGhosting_Send_AToken_Externally.test.js
+++ b/test/GoodGhosting_Send_AToken_Externally.test.js
@@ -51,6 +51,7 @@ contract("GoodGhosting_Send_AToken_Externally", (accounts) => {
     describe("simulates a full game with 5 players and 4 of them winning the game but considering an external adai transfer from admin", async () => {
         it("initializes contract instances and transfers DAI to players", async () => {
             token = new web3.eth.Contract(daiABI, providersConfigs.dai.address);
+            rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
             goodGhosting = await GoodGhostingArtifact.deployed();
             // Send 1 eth to token address to have gas to transfer DAI.
             // Uses ForceSend contract, otherwise just sending a normal tx will revert.
@@ -220,7 +221,6 @@ contract("GoodGhosting_Send_AToken_Externally", (accounts) => {
                 truffleAssert.eventEmitted(result, "Withdrawal", async (ev) => {
                     console.log(`player${i} withdraw amount: ${ev.amount.toString()}`);
                     if (GoodGhostingArtifact === GoodGhostingPolygon) {
-                        rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
                         const playersMaticBalance = new BN(await rewardToken.methods.balanceOf(player).call({ from: admin }));
                         return ev.player === player && new BN(ev.amount.toString()).gt(playerInfo.amountPaid) && playersMaticBalance.gt(new BN(0));
                     } else {
@@ -234,16 +234,19 @@ contract("GoodGhosting_Send_AToken_Externally", (accounts) => {
             if (!customFee) {
                 await truffleAssert.reverts(goodGhosting.adminFeeWithdraw({ from: admin }), "No Fees Earned");
             } else {
+                let adminMaticBalanceBeforeWithdraw;
+                if (GoodGhostingArtifact === GoodGhostingPolygon) {
+                    adminMaticBalanceBeforeWithdraw = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
+                }
                 const result = await goodGhosting.adminFeeWithdraw({ from: admin });
                 if (GoodGhostingArtifact === GoodGhostingPolygon) {
-                    rewardToken = new web3.eth.Contract(daiABI, providersConfigs.wmatic);
                     const adminMaticBalance = new BN(await rewardToken.methods.balanceOf(admin).call({ from: admin }));
                     truffleAssert.eventEmitted(
                         result,
                         "AdminWithdrawal",
                         (ev) => {
                             const adminFee = (new BN(configs.deployConfigs.customFee).mul(ev.totalGameInterest).div(new BN('100')));
-                                return adminFee.lte(ev.adminFeeAmount) && adminMaticBalance.eq(new BN(0));
+                                return adminFee.lte(ev.adminFeeAmount) && adminMaticBalance.eq(adminMaticBalanceBeforeWithdraw);
                         });
                 } else {
                     truffleAssert.eventEmitted(


### PR DESCRIPTION
- Removes the quickswap logic from the smart contract and winners get additional matic rewards
- Updated the fork test scenario's to cover the same 
- Updated polygon deployment config
- sanity check to make sure both mainnet and polygon tests work